### PR TITLE
Fixing typo in AddonManager

### DIFF
--- a/src/beast/util/AddOnManager.java
+++ b/src/beast/util/AddOnManager.java
@@ -655,7 +655,7 @@ public class AddOnManager {
                         if (loadedClass == null) {
                             addURL(url);
                         } else {
-                            Log.debug.println("Skip loading " + url + ": contains classs " + loadedClass + " that is already loaded");
+                            Log.debug.println("Skip loading " + url + ": contains class " + loadedClass + " that is already loaded");
                         }
                     }
                 }


### PR DESCRIPTION
contains classs X that is already loaded -> contains class X that is already loaded.